### PR TITLE
Enhance Swift Numerics README.md (technical writing perspective)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,154 @@
 # Swift Numerics
   
 ## Introduction
-Swift Numerics provides a set of modules that support numerical computing in Swift.
-These modules fall broadly into two categories:
 
-- API that is too specialized to go into the standard library, but which is sufficiently general to be centralized in a single common package.
-- API that is under active development toward possible future inclusion in the standard library.
+Swift Numerics provides a set of modules that support numerical computing in
+Swift. These modules fall broadly into two categories:
 
-There is some overlap between these two categories, and API that begins in the first category may migrate to the second as it matures and new uses are discovered.
+- API that is too specialized to go into the standard library, but which is
+  sufficiently general to be centralized in a single common package.
+- API that is under active development toward possible future inclusion in the
+  standard library.
 
-Swift Numerics modules are fine-grained; if you need support for Complex numbers, you can import ComplexModule¹ without pulling in everything else in the library as well:
+There is some overlap between these two categories, and API that begins in the
+first category may migrate into the second as it matures and more users start
+using Swift Numerics.
+
+Swift Numerics modules are fine-grained. For example, if you need support for
+Complex numbers, you can import ComplexModule¹ as a standalone module:
+
 ```swift
 import ComplexModule
 
 let z = Complex<Double>.i
 ```
-However, there is also a top-level `Numerics` module that simply re-exports the complete public interface of swift-numerics:
+
+There is also a top-level `Numerics` module that re-exports the complete public
+interface of swift-numerics:
+
 ```swift
 import Numerics
 
-// All swift-numerics API is now available
+// The entire `swift-numerics` API is now available
 ```
 
 Swift Numerics modules have minimal dependencies on other projects.
-The current modules assume only the availability of the Swift and C standard libraries and the runtime support provided by compiler-rt.
-Future expansion may assume the availability of other standard interfaces such as [BLAS (Basic Linear Algebra Subprograms)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) and [LAPACK (Linear Algebra Package)](https://en.wikipedia.org/wiki/LAPACK), but modules with more specialized dependencies (or dependencies that are not available on all platforms supported by Swift) belong in a separate package.
 
-Because we intend to make it possible to adopt Swift Numerics modules in the standard library at some future point, Swift Numerics uses the same license and contribution guidelines as the Swift project.
+The current modules assume only the availability of the Swift and C standard libraries and the runtime support provided by compiler-rt.
+
+Future expansion may assume the availability of other standard interfaces, such
+as [BLAS (Basic Linear Algebra
+Subprograms)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms)
+and [LAPACK (Linear Algebra Package)](https://en.wikipedia.org/wiki/LAPACK). But
+modules with more specialized dependencies (or dependencies that are not
+available on all platforms supported by Swift) belong in a separate package.
+
+The Swift Numerics project is intended to be adopted in the standard library
+in future. Therefore, it uses the same license and contribution guidelines as
+the Swift project.
 
 ## Using Swift Numerics in your project
-To use Swift Numerics in a SwiftPM project, add the following line to the dependencies in your `Package.swift` file:
+
+To use Swift Numerics in a SwiftPM project:
+
+1. Add the following line to the
+dependencies in your `Package.swift` file:
+
 ```swift
 .package(url: "https://github.com/apple/swift-numerics", from: "0.0.5"),
 ```
-add `Numerics` as a dependency for your target:
+
+2. Add `Numerics` as a dependency for your target:
+
 ```swift
 .target(name: "MyTarget", dependencies: [
   .product(name: "Numerics", package: "swift-numerics"),
   "AnotherModule"
 ]),
 ```
-and finally, add `import Numerics` in your source code.
-    
+
+3. Add `import Numerics` in your source code.
+
 ## Contributing to Swift Numerics
-Swift Numerics is a standalone library separate from the core Swift project.
-In practice, it will act as a staging ground for some APIs that may eventually be incorporated into the Swift Standard Library, and when that happens such changes will be proposed to the Swift Standard Library using the established evolution process of the Swift project.
 
-Swift Numerics uses GitHub issues to track bugs and features. We use pull requests for development.
+Swift Numerics is a standalone library that is separate from the core Swift
+project. In practice, it will act as a staging ground for some APIs that may
+eventually be incorporated into the Swift Standard Library. When that happens,
+such changes will be proposed to the Swift Standard Library using the
+established evolution process of the Swift project.
 
-To propose a new module:
+Swift Numerics uses GitHub issues to track bugs and features. We use pull
+requests for development.
+
+### How to propose a new module
+
 1. Raise an issue with the [new module] tag.
 2. Raise a PR with an implementation sketch.
-3. Once you have some consensus, ask an admin to create a feature branch against which PRs can be raised.
-4. When the design has stabilized and is functional enough to be useful, raise a PR to merge the new module to master.
+3. Once you have some consensus, ask an admin to create a feature branch against
+   which PRs can be raised.
+4. When the design has stabilized and is functional enough to be useful, raise a
+   PR to merge the new module to master.
 
-To propose a new feature for an existing module:
+### How to propose a new feature for an existing module
+
 1. Raise an issue with the [enhancement] tag.
 2. Raise a PR with your implementation, and discuss the implementation there.
-3. Once there is a consensus that the new feature is desirable and the design is suitable, it can be merged.
+3. Once there is a consensus that the new feature is desirable and the design is
+   suitable, it can be merged.
 
-To fix a bug, or make smaller improvements:
-1. Raise a PR with your change. Be sure to add test coverage for whatever changes you are making.
+### How to fix a bug, or make smaller improvements
 
-Questions about how to use Swift Numerics modules, or issues that are not clearly bugs can be discussed in the ["Swift Numerics" section of the Swift forums.](https://forums.swift.org/c/related-projects/swift-numerics)
+1. Raise a PR with your change. 
+2. Make sure to add test coverage for whatever changes you are making.
+
+### Forums
+
+Questions about how to use Swift Numerics modules, or issues that are not
+clearly bugs can be discussed in the ["Swift Numerics" section of the Swift
+forums](https://forums.swift.org/c/related-projects/swift-numerics).
 
 ## Modules
-1. [RealModule](Sources/RealModule/README.md)
-    - [Approximate Equality](Sources/RealModule/ApproximateEquality.swift)
-2. [ComplexModule](Sources/ComplexModule/README.md)
+
+1. About [`RealModule`](Sources/RealModule/README.md)
+    - [`ApproximateEquality`](Sources/RealModule/ApproximateEquality.swift)
+2. About [`ComplexModule`](Sources/ComplexModule/README.md)
 
 ## Future expansion
+
 1. [Large Fixed-Width Integers](https://github.com/apple/swift-numerics/issues/4)
 2. [Arbitrary-Precision Integers](https://github.com/apple/swift-numerics/issues/5)
 3. [Shaped Arrays](https://github.com/apple/swift-numerics/issues/6)
 4. [Decimal Floating-point](https://github.com/apple/swift-numerics/issues/7)
 
 ## Notes
-¹ Swift is currently unable to use the fully-qualified name for types when a type and module have the same name (discussion here: https://forums.swift.org/t/pitch-fully-qualified-name-syntax/28482).
-This would prevent users of Swift Numerics who don't need generic types from doing things like:
+
+¹ Swift is currently unable to use the fully-qualified name for types when a
+type and module have the same name (discussion here:
+https://forums.swift.org/t/pitch-fully-qualified-name-syntax/28482). This would
+prevent users of Swift Numerics who don't need generic types from doing things,
+such as:
+
 ```swift
 import Complex
-// I know I only ever want Complex<Double>, so I shouldn't need the generic parameter.
-typealias Complex = Complex.Complex<Double> // doesn't work, because name lookup fails.
+// You only ever want Complex<Double>, so you shouldn't need the generic parameter.
+typealias Complex = Complex.Complex<Double> // This doesn't work, because name lookup fails.
 ```
-For this reason, modules that would have this ambiguity are suffixed with `Module` within Swift Numerics:
+
+For this reason, modules that would have this ambiguity are suffixed with
+`Module` within Swift Numerics:
+
 ```swift
 import ComplexModule
-// I know I only ever want Complex<Double>, so I shouldn't need the generic parameter.
+// You only ever want Complex<Double>, so I shouldn't need the generic parameter.
 typealias Complex = ComplexModule.Complex<Double>
-// But I can still refer to the generic type by qualifying the name if I need it occasionally:
+// But you can still refer to the generic type by qualifying the name 
+// if you need it occasionally:
 let a = ComplexModule.Complex<Float>
 ```
-The `Real` module does not contain a `Real` type, but does contain a `Real` protocol, and users may want to define their own `Real` type (and possibly re-export the `Real` module), so the suffix is also applied there.
- New modules have to evaluate this decision carefully, but can err on the side of adding the suffix.
- It's expected that most users will simply `import Numerics`, so this isn't an issue for them.
+
+The `Real` module does not contain a `Real` type, but does contain a `Real`
+protocol, and users may want to define their own `Real` type (and possibly
+re-export the `Real` module) - that why why the suffix is also applied there.
+New modules have to evaluate this decision carefully, but can err on the side of
+adding the suffix. It's expected that most users will simply `import Numerics`,
+so this isn't an issue for them.


### PR DESCRIPTION
Hey @markuswntr!

I've looked at your Swift Numerics PR (`ApproximateEquality`): https://github.com/apple/swift-numerics/pull/150 and thought we could bundle a few changes together.

I've made a few improvement suggestions to the entire README based on tech writing experience - hope you like them:

- Small change: "may migrate in the second" -> "may migrate into the second"
- Refactor: "new uses are discovered" (passive voice) -> "more users start using Swift Numerics." (active voice)
- Reduce the use of "simply" if possible (it's not necessary but is recommended)
- Refactor + replace the idiom ("to pull in") for internalization/inclusiveness:

```diff
- Swift Numerics modules are fine-grained; if you need support for Complex
+ Swift Numerics modules are fine-grained. For example, if you need support for
+ Complex numbers ...
- ... import ComplexModule¹ without pulling in everything else in the library:
+ ... import ComplexModule¹ as a standalone module:
...
- as well.
...
[Example in code blocks]
```

- Refactor:

```diff
- // All swift-numerics API is now available
+ // The entire `swift-numerics` API is now available
```

- Replace the use of "we" with "the Swift Numerics project". For example:

```diff
- Because we intend to make it possible to adopt Swift Numerics modules in the
- standard library at some future point...
+ The Swift Numerics project is intended to be adopted in the standard library
+ in future. Therefore, it...
```

- Provide three steps (`1... 2... 3...`) for the Using Swift Numerics in your project section, since it's a sequential process - this helps with UX
- Small refactor: add "that is"

```diff
- Swift Numerics is a standalone library separate from the core Swift project. In
+ Swift Numerics is a standalone library that is separate from the core Swift project. In
```

- Enhance several HowTo sections under "Contributing..." into discoverable subheadings (e.g. "to propose a new module" -> "# How to propose a new module")
- Add a "### Forums" section for improved discoverability
- Add "About" to enhance explanations of the links:

```
1. About [`RealModule`](Sources/RealModule/README.md)
    - [`ApproximateEquality`](Sources/RealModule/ApproximateEquality.swift)
2. About [`ComplexModule`](Sources/ComplexModule/README.md)
```

- Reformat the Markdown text to wrap at 80 characters (it's a good practice, just like in code)
- Turn complex sentences -> smaller easier to follow sentences
- Use second person ("you") instead of first person ("I", "we"), if you can
- Add blank lines between the section titles and first paragraphs
- Add blank lines between before and after code blocks

Let me know what you think.

Cheers!