### PR TITLE
Unwrap text, update Swift Numerics README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,14 @@
   
 ## Introduction
 
-Swift Numerics provides a set of modules that support numerical computing in
-Swift. These modules fall broadly into two categories:
+Swift Numerics provides a set of modules that support numerical computing in Swift. These modules fall broadly into two categories:
 
-- API that is too specialized to go into the standard library, but which is
-  sufficiently general to be centralized in a single common package.
-- API that is under active development toward possible future inclusion in the
-  standard library.
+- API that is too specialized to go into the standard library, but which is sufficiently general to be centralized in a single common package.
+- API that is under active development toward possible future inclusion in the standard library.
 
-There is some overlap between these two categories, and API that begins in the
-first category may migrate into the second as it matures and more users start
-using Swift Numerics.
+There is some overlap between these two categories, and an API that begins in the first category may migrate into the second as it matures and more users start using Swift Numerics.
 
-Swift Numerics modules are fine-grained. For example, if you need support for
-Complex numbers, you can import ComplexModule¹ as a standalone module:
+Swift Numerics modules are fine-grained. For example, if you need support for Complex numbers, you can import ComplexModule¹ as a standalone module:
 
 ```swift
 import ComplexModule
@@ -23,8 +17,7 @@ import ComplexModule
 let z = Complex<Double>.i
 ```
 
-There is also a top-level `Numerics` module that re-exports the complete public
-interface of Swift Numerics:
+There is also a top-level `Numerics` module that re-exports the complete public interface of Swift Numerics:
 
 ```swift
 import Numerics
@@ -36,23 +29,15 @@ Swift Numerics modules have minimal dependencies on other projects.
 
 The current modules assume only the availability of the Swift and C standard libraries and the runtime support provided by compiler-rt.
 
-Future expansion may assume the availability of other standard interfaces, such
-as [BLAS (Basic Linear Algebra
-Subprograms)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms)
-and [LAPACK (Linear Algebra Package)](https://en.wikipedia.org/wiki/LAPACK). But
-modules with more specialized dependencies (or dependencies that are not
-available on all platforms supported by Swift) belong in a separate package.
+Future expansion may assume the availability of other standard interfaces, such as [BLAS (Basic Linear Algebra Subprograms)](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) and [LAPACK (Linear Algebra Package)](https://en.wikipedia.org/wiki/LAPACK). But modules with more specialized dependencies (or dependencies that are not available on all platforms supported by Swift) belong in a separate package.
 
-Because we intend to make it possible to adopt Swift Numerics modules in the
-standard library at some future point, Swift Numerics uses the same license and
-contribution guidelines as the Swift project.
+Because we intend to make it possible to adopt Swift Numerics modules in the standard library at some future point, Swift Numerics uses the same license and contribution guidelines as the Swift project.
 
 ## Using Swift Numerics in your project
 
 To use Swift Numerics in a SwiftPM project:
 
-1. Add the following line to the
-dependencies in your `Package.swift` file:
+1. Add the following line to the dependencies in your `Package.swift` file:
 
 ```swift
 .package(url: "https://github.com/apple/swift-numerics", from: "0.0.7"),
@@ -71,30 +56,22 @@ dependencies in your `Package.swift` file:
 
 ## Contributing to Swift Numerics
 
-Swift Numerics is a standalone library that is separate from the core Swift
-project. In practice, it will act as a staging ground for some APIs that may
-eventually be incorporated into the Swift Standard Library. When that happens,
-such changes will be proposed to the Swift Standard Library using the
-established evolution process of the Swift project.
+Swift Numerics is a standalone library that is separate from the core Swift project. In practice, it will act as a staging ground for some APIs that may eventually be incorporated into the Swift Standard Library. When that happens, such changes will be proposed to the Swift Standard Library using the established evolution process of the Swift project.
 
-Swift Numerics uses GitHub issues to track bugs and features. We use pull
-requests for development.
+Swift Numerics uses GitHub issues to track bugs and features. We use pull requests for development.
 
 ### How to propose a new module
 
 1. Raise an issue with the [new module] tag.
 2. Raise a PR with an implementation sketch.
-3. Once you have some consensus, ask an admin to create a feature branch against
-   which PRs can be raised.
-4. When the design has stabilized and is functional enough to be useful, raise a
-   PR to merge the new module to master.
+3. Once you have some consensus, ask an admin to create a feature branch against which PRs can be raised.
+4. When the design has stabilized and is functional enough to be useful, raise a PR to merge the new module to master.
 
 ### How to propose a new feature for an existing module
 
 1. Raise an issue with the [enhancement] tag.
 2. Raise a PR with your implementation, and discuss the implementation there.
-3. Once there is a consensus that the new feature is desirable and the design is
-   suitable, it can be merged.
+3. Once there is a consensus that the new feature is desirable and the design is suitable, it can be merged.
 
 ### How to fix a bug, or make smaller improvements
 
@@ -103,9 +80,7 @@ requests for development.
 
 ### Forums
 
-Questions about how to use Swift Numerics modules, or issues that are not
-clearly bugs can be discussed in the ["Swift Numerics" section of the Swift
-forums](https://forums.swift.org/c/related-projects/swift-numerics).
+Questions about how to use Swift Numerics modules, or issues that are not clearly bugs can be discussed in the ["Swift Numerics" section of the Swift forums](https://forums.swift.org/c/related-projects/swift-numerics).
 
 ## Modules
 
@@ -121,11 +96,7 @@ forums](https://forums.swift.org/c/related-projects/swift-numerics).
 
 ## Notes
 
-¹ Swift is currently unable to use the fully-qualified name for types when a
-type and module have the same name (discussion here:
-https://forums.swift.org/t/pitch-fully-qualified-name-syntax/28482). This would
-prevent users of Swift Numerics who don't need generic types from doing things,
-such as:
+¹ Swift is currently unable to use the fully-qualified name for types when a type and module have the same name (discussion here: https://forums.swift.org/t/pitch-fully-qualified-name-syntax/28482). This would prevent users of Swift Numerics who don't need generic types from doing things, such as:
 
 ```swift
 import Complex
@@ -133,8 +104,7 @@ import Complex
 typealias Complex = Complex.Complex<Double> // This doesn't work, because name lookup fails.
 ```
 
-For this reason, modules that would have this ambiguity are suffixed with
-`Module` within Swift Numerics:
+For this reason, modules that would have this ambiguity are suffixed with `Module` within Swift Numerics:
 
 ```swift
 import ComplexModule
@@ -144,9 +114,4 @@ typealias Complex = ComplexModule.Complex<Double>
 let a = ComplexModule.Complex<Float>
 ```
 
-The `Real` module does not contain a `Real` type, but does contain a `Real`
-protocol, and users may want to define their own `Real` type (and possibly
-re-export the `Real` module) - that why why the suffix is also applied there.
-New modules have to evaluate this decision carefully, but can err on the side of
-adding the suffix. It's expected that most users will simply `import Numerics`,
-so this isn't an issue for them.
+The `Real` module does not contain a `Real` type, but does contain a `Real` protocol, and users may want to define their own `Real` type (and possibly re-export the `Real` module) - that is why the suffix is also applied there. New modules have to evaluate this decision carefully, but can err on the side of adding the suffix. It's expected that most users will simply `import Numerics`, so this isn't an issue for them.


### PR DESCRIPTION
- Unwrapping the text as per the feedback in https://github.com/apple/swift-numerics/pull/150
- Also, the grammar/syntax checker spotted two minor syntactical errors ("and API that begins in ..." -> "and an API that begins in...", ".. that why why the suffix ..." -> "... that is why the suffix ...")